### PR TITLE
chore(release-drafter) allow manual trigger of the workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   update_release_draft:


### PR DESCRIPTION
As per https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#workflow_dispatch