### PR TITLE
feat(rating/docker): upgrade from php image 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM php:5.6-apache
+FROM php:8.2-apache
 
 # docker php image has its own way of installing a module
 RUN apt-get update \
-  && apt-get install --no-install-recommends -y libpq-dev=9.6.24-0+deb9u1 \
+  && apt-get install --no-install-recommends -y libpq-dev=15.3-0+deb12u1 \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 

--- a/src/submit.php
+++ b/src/submit.php
@@ -4,8 +4,8 @@
     require_once('/config/dbconfig.php');
     $db = @pg_connect("user=$dbuser password=$dbpass host=$dbserver dbname=$dbname");
     if (!$db) die('DB error');
-    $voter = $_SERVER['HTTP_X_FORWARDED_FOR'];
-    if (empty($voter)) $voter = $_SERVER['REMOTE_ADDR'];
+    $voter = getenv('HTTP_X_FORWARDED_FOR');
+    if (empty($voter)) $voter = getenv('REMOTE_ADDR');
     if ($_GET['rating'] == 1) {
       pg_insert($db, 'jenkins_good', array('version' => $_GET['version'], 'voter' => $voter));
     } else {


### PR DESCRIPTION
following build error on master https://infra.ci.jenkins.io/blue/organizations/jenkins/docker-jobs%2Frating/detail/PR-31/1/pipeline

I choose the 8.2 php version as per https://www.php.net/supported-versions.php
and upgrade to the current `libpq-dev=15.3-0+deb12u1` for this version

the test showed an error 
```
<b>Warning</b>:  Undefined array key "HTTP_X_FORWARDED_FOR" in <b>/var/www/html/rate/submit.php</b> on line <b>7</b><br />
```

so I changed the php $_SERVER to getenv as proposed here : https://stackoverflow.com/questions/9548934/notice-undefined-index-http-x-forwarded-for-error-in-function