### PR TITLE
Reduce risk of empty 'last changes' from release drafter

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -12,7 +12,12 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@139054aeaa9adc52ab36ddf67437541f039b88e2 # v7.1.1
+      # https://github.com/release-drafter/release-drafter/issues/871#issuecomment-3686135188
+      - name: Wait for 15 seconds to ensure GraphQL consistency
+        shell: bash
+        run: sleep 15s
+      - name: Release Drafter
+        uses: release-drafter/release-drafter@139054aeaa9adc52ab36ddf67437541f039b88e2 # v7.1.1
         with:
           # This token is generated automatically by default in GitHub Actions: no need to create it manually
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Reduce risk of empty 'last changes' from release drafter

There have been several releases that list "No changes" even though there were changes in the release, including:

* https://github.com/jenkins-infra/rating/releases/tag/0.1.12
* https://github.com/jenkins-infra/rating/releases/tag/0.1.9
* https://github.com/jenkins-infra/rating/releases/tag/0.1.6

Issue https://github.com/release-drafter/release-drafter/issues/871 includes this comment:

> PR's associated with commits are coming from GH's GraphQL API, and that
> needs some time to process the same event, that triggered the release
> drafter itself. We added a 15s delay before running the release drafter
> step, ugly but works.

A later comment from the release drafter maintainer says:

> this is high-effort fix with low-effort workaround.
>
> Issue comes from GitHub's Graphql Commit-to-PR relation
> associatedPullRequests, which take some time for github to compute. When
> you push to main and trigger a release-drafter run, you sometimes end
> up being faster than Github's backend and may miss this relation.
>
> To prevent this, simply delay your release-drafter run as @lmagyar suggested.

## Testing done

None.  Rely on GitHub action run when the pull request is merged
